### PR TITLE
Move travis.yml to project root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+
+go:
+- 1.18


### PR DESCRIPTION
This PR moves the `.travis.yml` file to the project root.